### PR TITLE
Fix installing problem on Raspberry Pi

### DIFF
--- a/installer/Ubuntu_and_Raspbian/install.sh
+++ b/installer/Ubuntu_and_Raspbian/install.sh
@@ -9,7 +9,7 @@ else
 	python3 -m pip install -r ../deps/requirements_linux.txt
 fi
 
-sudo sh install-opencv.sh
+sudo ./install-opencv.sh
 
 sudo cp 99-hornedsungem.rules /etc/udev/rules.d/
 sudo chmod +x /etc/udev/rules.d/99-hornedsungem.rules


### PR DESCRIPTION
Use bash instead of sh. Otherwise bash will throw the following
error on Raspberry Pi.
```
install-opencv.sh: 14: install-opencv.sh: [[: not found
Installing opencv python for non-Raspbian
```